### PR TITLE
Optimize get_total_path_distance calls

### DIFF
--- a/actors/chicken/chicken.gd
+++ b/actors/chicken/chicken.gd
@@ -11,36 +11,25 @@ onready var mob
 
 var target setget , get_target
 
-var power = 1
-var attack_speed = 1
-#var projectile_speed = 100
-#var projectile_speed = 250
-var projectile_speed = 300
+#var luck #TODO Implement luck for more chance at rare drops (helmets and egg production)
+var power = 1 # The damage this chicken does on hit
+var attack_speed = 1 # Lower attack speed = more shots per second
+var projectile_speed = 250
 
 var machine_operated #TODO switch this to "nestbox" if in a nestbox, "tower" if in a tower
 
 var projectile = load("res://items/projectile_egg.tscn")
 
-var chase = true
+#var chase = false # TODO make this be a thing for certain towers
 
 var adjectives = []
 
 ## FUNCS
-
-
-## SIGNALS
 func release():
 	chicken_trail.handle_grabbed_chicken_dropped()
 
-#func _on_mouse_entered():
-##	print("mouse_entered %s" % [self])
-#	if not Util.selected_chicken:
-#		Util.selected_chicken = self
-#
-#func _on_mouse_exited():
-##	print("mouse_exited %s" % [self])
-#	if Util.selected_chicken == self:
-#		Util.selected_chicken = null
+## SIGNALS
+
 
 ## SETGET
 func get_state():
@@ -62,5 +51,3 @@ func get_mob_priority():
 ## EXECUTION
 func _ready():
 	add_to_group("chicken")
-#	connect("mouse_entered", self, "_on_mouse_entered")
-#	connect("mouse_exited", self, "_on_mouse_exited")

--- a/actors/mob/mob.gd
+++ b/actors/mob/mob.gd
@@ -12,14 +12,12 @@ onready var astar_nav = $"/root/main/astar_nav"
 
 # Movement
 var velocity = Vector2()
-#export(float) var speed = 0.5 setget , get_speed
-#export(float) var speed = 50 setget , get_speed
-export(float) var speed = 30 # setget , get_speed
+export(float) var speed = 30
 var distance setget , get_distance
 
 # Stats
 export(int) var max_health = 3
-export(int) var health = max_health # setget , get_health
+export(int) var health = max_health
 
 # References
 onready var screen_size = get_viewport_rect().size
@@ -45,18 +43,9 @@ func kill():
 
 
 ## SETGET
-#func get_mob_type():
-#	return mob_type
-
-#func get_speed():
-#	return speed
-
 func get_distance():
-#	return astar_nav.get_total_path_distance()
-	return mob_navigation.get_total_path_distance()
+	return mob_navigation.total_path_distance
 
-#func get_health():
-#	return health
 
 ## EXECUTION
 func _ready():

--- a/actors/mob/mob_navigation_astar.gd
+++ b/actors/mob/mob_navigation_astar.gd
@@ -1,21 +1,21 @@
 extends Node
 
 ## VARS
-onready var mob = get_parent() # is the mob
-onready var last_point = mob.global_position # needed for mob
-
 onready var astar_nav = $"/root/main/astar_nav"
-
 onready var path = astar_nav.path
-#onready var astar_nav = $"/root/AstarNav"
+
+onready var mob = get_parent()
+onready var last_point = mob.global_position
+
+
+var total_path_distance
+
 
 ## FUNCS
 func move_along_path(distance):
 	last_point = mob.global_position
 
 	while path.size():
-#	while path.size():
-#		var next_point = tilemap_ground.map_to_world(path[0])
 		var next_point = astar_nav.tilemap_ground.map_to_world(path[0])
 		var distance_between_points = last_point.distance_to(next_point)
 
@@ -32,7 +32,7 @@ func move_along_path(distance):
 		path.remove(0)
 
 
-func get_total_path_distance():
+func calculate_total_path_distance():
 	if path.size() > 0:
 		var distance = 0.0
 
@@ -45,9 +45,6 @@ func get_total_path_distance():
 				distance += astar_nav.tilemap_ground.map_to_world(path[index]).distance_to(astar_nav.tilemap_ground.map_to_world(path[index-1]))
 
 		return distance
-	else:
-		# path is empty
-		pass
 
 ## SIGNALS
 
@@ -57,7 +54,5 @@ func get_total_path_distance():
 
 ## EXECUTION
 func _process(delta):
-#	if path:
+	total_path_distance = calculate_total_path_distance()
 	move_along_path(mob.speed * delta)
-#	else:
-#		return

--- a/scripts/AStarPath.gd
+++ b/scripts/AStarPath.gd
@@ -7,14 +7,8 @@ onready var tilemap_buildings = $"/root/main/tilemap_buildings"
 onready var tilemap_ground = $"/root/main/tilemap_ground"
 
 onready var astar = AStar2D.new()
-#onready var used_cells = reference_tilemap.get_used_cells()
 
-#export var tilemap_size := Vector2(17, 11)
-#export var tilemap_top_left := Vector2(10,4)
-#export var tilemap_bottom_right := Vector2()
-#var tilemap_rect = Rect2(24, 14, 13, 11)
-
-var path: PoolVector2Array# setget, get_path
+var path: PoolVector2Array
 
 
 
@@ -26,49 +20,17 @@ var walkable_cells_array: Array # Contains all the cells which are available for
 func update_cells_arrays():
 	ground_array = tilemap_ground.get_used_cells()
 	obstacles_array = tilemap_buildings.get_used_cells()
-#	obstacles_array = obstacles_tilemap.get_used_cells()
 	
-#	for y_index in range(tilemap_size.y):
-#	for y_index in range(tilemap_top_left.y, tilemap_size.y + tilemap_top_left.y):
 	for tile in ground_array:
-#		print("y_index: ", y_index)
-#		for x_index in range(tilemap_top_left.x, tilemap_size.x + tilemap_top_left.x):
-#			print("x_index: ", x_index)
-			
-#			if not Vector2(x_index, y_index) in obstacles_array :
 			if not tile in obstacles_array :
-#				print("(%s, %s)" % [x_index, y_index])
-#			if not obstacles_array.has(Vector2(x_index, y_index)):
-#			if not obstacles_array[obstacles_array.find(Vector2(x_index, y_index))]:
-#			if not obstacles_tilemap.get_cell(x_index, y_index): #TODO not fixed but close
-#				walkable_cells_array.append(Vector2(x_index + tilemap_top_left.x, y_index + tilemap_top_left.y))
-				
-#				walkable_cells_array.append(Vector2())
-				
-#				walkable_cells_array.append(Vector2(x_index, y_index))
 				walkable_cells_array.append(tile)
-#				print("yay")
-		
-#	print(walkable_cells_array) #TODO not fixed but close
 
 func _add_points():
-#	print("foo")
-	
 	for cell in walkable_cells_array:
-#		astar.add_point(id(x_index + tilemap_top_left.x), id(y_index + tilemap_top_left.y))
 		astar.add_point(id(cell), cell)
-#		astar.add_point(id(cell.x), cell.y)
-
-
-#	for cell in used_cells:
-#		if not obstacles_tilemap.get_cell(cell.x, cell.y):
-#			astar.add_point(id(cell), cell)
 
 func _connect_points():
-#	for cell in used_cells:
 	for cell in walkable_cells_array:
-#		if not obstacles_tilemap.get_cell(cell.x, cell.y):
-			# Check neighbors
 			var neighbors = [Vector2.LEFT, Vector2.RIGHT, Vector2.UP, Vector2.DOWN]
 			
 			for neighbor in neighbors:
@@ -76,21 +38,10 @@ func _connect_points():
 				if walkable_cells_array.has(next_cell):
 					astar.connect_points(id(cell), id(next_cell))
 
-#func _get_path(start, end): #TODO make this work
-func _calculate_path(start, end): #TODO make this work
-#	if path:
-#		path = astar.get_point_path(id(start), id(end))
-#	else:
-#		print("[dbg] There is no path from %s to %s" % [start, end])
-#		#TODO emit signal when this happens, to tell the game the player is blocking the path
-#
-#	path.remove(0)
+func _calculate_path(start, end):
 	path = astar.get_point_path(id(start), id(end))
 	path.remove(0)
 
-#func get_path():
-#	return path
-	
 
 func id(point):
 	var a = point.x

--- a/scripts/astar_nav.gd
+++ b/scripts/astar_nav.gd
@@ -1,56 +1,10 @@
 extends AStarPath
 
 ## VARS
-#onready var mob = get_parent() # is the mob
-#onready var last_point = mob.global_position # needed for mob
-
 onready var start_position = tilemap_ground.world_to_map($"/root/main/start_position".global_position)
 onready var end_position = tilemap_ground.world_to_map($"/root/main/end_position".global_position)
 
-
-## DBG
-#var velocity = Vector2()
-#var speed = 50
-
 ## FUNCS
-
-	
-#func move_along_path(distance):
-#	last_point = mob.global_position
-#
-#	while path.size():
-#		var next_point = tilemap_ground.map_to_world(path[0])
-#		var distance_between_points = last_point.distance_to(next_point)
-#
-#		# The position to move to falls between two points.
-#		if distance <= distance_between_points:
-#			mob.global_position = last_point.linear_interpolate(next_point, \
-#				distance / distance_between_points)
-#			return
-#
-#		# The position is past the end of the segment.
-#		distance -= distance_between_points
-#		last_point = tilemap_ground.map_to_world(path[0])
-#
-#		path.remove(0)
-#
-#
-#func get_total_path_distance():
-#	if path.size() > 0:
-#		var distance = 0.0
-#
-#		var mob_position = mob.global_position
-#
-#		distance += tilemap_ground.map_to_world(path[0]).distance_to(mob_position)
-#
-#		for index in range(path.size()):
-#			if index != 0:
-#				distance += tilemap_ground.map_to_world(path[index]).distance_to(tilemap_ground.map_to_world(path[index-1]))
-#
-#		return distance
-#	else:
-#		# path is empty
-#		pass
 
 ## SIGNALS
 
@@ -61,16 +15,5 @@ onready var end_position = tilemap_ground.world_to_map($"/root/main/end_position
 ## EXECUTION
 
 func _ready():
-	#TODO change this thing to obtain path from a central astar_nav, and move the movement stuff to a new mob_navigation
 	_calculate_path(start_position, end_position)  
-	# get_path(astar_nav) #TODO 
-	
-	#TODO clear path and run _get_path() when player modifies the board. 
-	#If there is no available path, remove the building.
-
-#func _process(delta):
-##	if path:
-#	move_along_path(mob.speed * delta)
-##	else:
-##		return
 

--- a/scripts/mob_spawn.gd
+++ b/scripts/mob_spawn.gd
@@ -6,8 +6,6 @@ const DEBUG = false
 var spawn_timer = Timer.new()
 
 export var disabled = false
-#export var cell_size := Vector2(16, 16)
-
 
 var current_mob
 
@@ -62,7 +60,6 @@ func spawn_mob():
 		#TODO announce the stop of the wave (signal)
 		pass
 
-#TODO func add_wave(
 
 func add_wave_clump(p_wave: Wave = wave, spawn_amount:int = 5, spawn_speed: float = 1.5):
 #	var new_wave = Wave.new() #TODO probably shouldn't instantiate a whole new wave every clump
@@ -90,11 +87,8 @@ func _ready():
 	# Spawn Timer
 	add_child(spawn_timer)
 	spawn_timer.connect("timeout", self, "_on_spawn_timer_timeout")
-	
-	# Start the wave
-	# start_wave()
 
-func _physics_process(_delta):	
+func _physics_process(_delta):
 	# [dbg] Press "spacebar" to add a test wave clump to waves
 	if Input.is_action_just_pressed("ui_accept"):
 		add_wave_clump(wave) # Modify this method to send something different
@@ -107,5 +101,4 @@ func _physics_process(_delta):
 	
 	
 	if current_wave_clump and not disabled and not waves.empty():
-#	if current_wave_clump and not current_wave_clump.size() == 0 and not disabled and not waves.empty():
 		start_wave()


### PR DESCRIPTION
It started getting super laggy once the screen had a lot of mobs. Go
stress tests I guess lol.

Ended up making sure that get_total_path_distance would only get the
value of the path, not recalculate the whole path distance for every mob
inside the detection radius of a chicken.

Modified the mob_navigation to calculate it's own total path distance every
_process execution instead of letting the chickens ask for it a few
hundred times a second lol.