### PR TITLE
Fix some wave_clump settings carrying over other clumps.

### DIFF
--- a/actors/chicken/chicken_trail.gd
+++ b/actors/chicken/chicken_trail.gd
@@ -9,6 +9,9 @@ var chicken_ghost_res = load("res://actors/chicken/chicken_ghost.tscn")
 var ghost: Node2D
 
 onready var player_buildings = $"/root/main/player_buildings" as TileMap
+onready var build_empty = $"/root/main/CanvasLayer/build_empty" as TextureButton
+onready var build_fence = $"/root/main/CanvasLayer/build_fence" as TextureButton
+
 onready var chicken = get_parent()
 onready var util = $"/root/main/util"
 #onready var chickens = get_tree().get_nodes_in_group("chicken")
@@ -17,6 +20,11 @@ onready var util = $"/root/main/util"
 func _on_input_event(_viewport, event, _shape_idx):
 	if event is InputEventMouseButton and event.get_button_index() == 1:
 		if event.is_pressed() and not util.grabbed_chicken:
+			util.unpress_buttons()
+			
+			
+#			util.selected_building = util.Cells.INVALID
+			
 			util.grabbed_chicken = chicken
 			ghost = chicken_ghost_res.instance()
 			add_child(ghost)
@@ -28,7 +36,8 @@ func _on_input_event(_viewport, event, _shape_idx):
 func handle_grabbed_chicken_dropped():
 	var cell = util.selected_cell
 	
-	if cell.id == util.Cells.FENCE:
+#	if cell.id == util.Cells.FENCE:
+	if not cell.id == util.Cells.EMPTY:
 		if cell.coordinates == chicken.current_cell.coordinates:
 			if DEBUG:
 				print("[dbg] Already at destination.")

--- a/scripts/DebugLabel.gd
+++ b/scripts/DebugLabel.gd
@@ -52,7 +52,7 @@ func update_debug_message():
 			util.Cells.GRASS: cell_name = "Grass"
 			util.Cells.FENCE: cell_name = "Fence"
 			util.Cells.DIRT: cell_name = "Dirt"
-			util.Cells.TOWER: cell_name = "Platform base (tower/nestbox)" # "tower"
+			util.Cells.NESTBOX: cell_name = "Platform base (nestbox)" # "tower"
 			4: cell_name = "chicken-placeholder"
 	
 		add_debug_message( \

--- a/scripts/mob_spawn.gd
+++ b/scripts/mob_spawn.gd
@@ -1,7 +1,7 @@
 extends Node2D
 
 ## VARS
-const DEBUG = false
+const DEBUG = true
 
 var spawn_timer = Timer.new()
 var current_mob
@@ -13,64 +13,59 @@ onready var wave = Wave.new()
 
 onready var main = $"/root/main"
 onready var zone_path = $"/root/main/zone_path" as TileMap
-onready var Util = $"/root/main/util"
+onready var util = $"/root/main/util"
 
 signal wave_ended
 
 ## FUNCS
 func start_wave():
-	
-	
 	if current_wave_clump and not waves.empty():
 		if waves[0].wave_clumps.empty():
 			return
-		current_wave_clump = waves[0].wave_clumps[0]
-		current_mob = load(current_wave_clump.spawn_mob)
 		
 		if spawn_timer.is_stopped():
 			spawn_timer.start(current_wave_clump.spawn_speed)
-			Util.enter_state(Util.GameModes.WAVE)
+			util.enter_state(util.GameModes.WAVE)
 	else:
 		return
 	
 
-
 func spawn_mob():
-	current_wave_clump = waves[0].wave_clumps[0]
-	spawn_timer.wait_time = current_wave_clump.spawn_speed
-	
-	if current_wave_clump and current_mob:
+	if not waves[0].wave_clumps.empty() and not waves.empty():
+		current_wave_clump = waves[0].wave_clumps[0]
 		spawn_timer.wait_time = current_wave_clump.spawn_speed
-		var new_mob = current_mob.instance()
-#		get_parent().add_child_below_node(self, new_mob)
-		main.add_child_below_node(self, new_mob)
-#		new_mob.position = self.position
-		new_mob.position = self.position - Vector2(zone_path.cell_size.x / 2, zone_path.cell_size.y / 2)
+
+		current_mob = load(current_wave_clump.spawn_mob)
 		
-		current_wave_clump.spawn_amount -= 1
-	
-	if current_wave_clump.spawn_amount == 0: 
-		# There are no more mobs in waves[0].wave_clumps[0]
-		waves[0].wave_clumps.pop_front()
-		spawn_timer.stop()
-	
-	if waves[0].wave_clumps.size() == 0:
-		# There are no more wave_clumps in waves[0].wave_clumps
-		waves.pop_front()
-	
-	if waves.size() == 0:
-		# There are no more waves in waves
-#		spawn_timer.stop() # not necessary as there is already a check when the wave clump is done.
-		#TODO announce the stop of the wave (signal)
-		emit_signal("wave_ended")
-#		Util.enter_state(Util.GameModes.BUILD)
+		if current_wave_clump and current_mob:
+			var new_mob = current_mob.instance()
+			main.add_child_below_node(self, new_mob)
+			new_mob.position = self.position - Vector2(zone_path.cell_size.x / 2, zone_path.cell_size.y / 2)
+			current_wave_clump.spawn_amount -= 1
+		
+		if current_wave_clump.spawn_amount == 0: 
+			# There are no more mobs in waves[0].wave_clumps[0]
+			waves[0].wave_clumps.pop_front()
+			
+			if waves[0].wave_clumps.empty():
+				# There are no more wave_clumps in waves[0].wave_clumps
+				waves.pop_front()
+				spawn_timer.stop()
+				emit_signal("wave_ended")
+			else: # There are still clumps left
+				current_wave_clump = waves[0].wave_clumps[0]
+				spawn_timer.wait_time = current_wave_clump.spawn_speed
+		
+		if waves.empty():
+			# There are no more waves in waves
+			# The game is over
+			if DEBUG:
+				print("No more waves!")
 
-
-func add_wave_clump(p_wave: Wave = wave, spawn_amount:int = 5, spawn_speed: float = 1.5, spawn_mob: String = "res://actors/mob/mob_fox.tscn"):
-#	var new_wave = Wave.new() #TODO probably shouldn't instantiate a whole new wave every clump
+func add_wave_clump(p_wave: Wave = wave, spawn_amount:int = 5, \
+spawn_speed: float = 1.5, spawn_mob: String = "res://actors/mob/mob_fox.tscn"):
 	var wave_clump = WaveClump.new()
 	
-#	wave_clump.spawn_mob = "res://actors/mob/mob_fox.tscn"
 	wave_clump.spawn_amount = spawn_amount
 	wave_clump.spawn_speed = spawn_speed
 	wave_clump.spawn_mob = spawn_mob
@@ -85,9 +80,9 @@ func add_wave_clump(p_wave: Wave = wave, spawn_amount:int = 5, spawn_speed: floa
 ## SIGNALS
 func _on_spawn_timer_timeout():	
 	spawn_mob()
-	
 
 ## SETGET
+
 
 ## EXECUTION
 func _ready():
@@ -96,7 +91,7 @@ func _ready():
 	spawn_timer.connect("timeout", self, "_on_spawn_timer_timeout")
 
 func _physics_process(_delta):
-#	if Util.game_mode == Util.GameModes.WAVE:
+	#TODO prepare multiple waves in advance (json?)
 	# [dbg] Press "spacebar" to add a test wave clump to waves
 	if Input.is_action_just_pressed("ui_accept"):
 #		add_wave_clump(wave) # Modify this method to send something different
@@ -104,13 +99,8 @@ func _physics_process(_delta):
 		add_wave_clump(wave, 1, 0.5, "res://actors/mob/mob_wolf.tscn") # 1 wolf
 	
 	if Input.is_action_just_pressed("ui_down"):
-#		add_wave_clump(wave, 10, 0.5)
 		add_wave_clump(wave, 10, 1, "res://actors/mob/mob_fox.tscn") # 10 foxes
 	
 	if Input.is_action_just_pressed("ui_up"):
-#		add_wave_clump(wave, 1, 0.1)
 		add_wave_clump(wave, 3, 2, "res://actors/mob/mob_bear.tscn") # 3 bears
 	
-	
-#	if current_wave_clump and not waves.empty() and Util.game_mode == Util.GameModes.BUILD:
-#		start_wave() # TODO make this not triggered by physics_process

--- a/scripts/player_buildings.gd
+++ b/scripts/player_buildings.gd
@@ -15,7 +15,8 @@ func _handle_building():
 	if util.game_mode == util.GameModes.BUILD and util.selected_building and not util.selected_building == -10 and not util.grabbed_chicken:
 		var old_cell = Cell.new(util.selected_cell.id, util.selected_cell.coordinates)
 		var new_cell = Cell.new(util.selected_building, util.selected_cell.coordinates)
-			
+		
+		
 		if Input.is_action_pressed("click") \
 			and not zone_build.get_cellv(util.selected_cell.coordinates) == -1 \
 			and not old_cell.id == new_cell.id:

--- a/scripts/util.gd
+++ b/scripts/util.gd
@@ -6,11 +6,12 @@ enum GameModes {
 	WAVE, # During waves
 }
 enum Cells {
+	INVALID = -10,
 	EMPTY = -1,
 	GRASS = 0,
 	FENCE = 1,
 	DIRT = 2,
-	TOWER = 3,
+	NESTBOX = 3,
 }
 
 var selected_cell: Cell
@@ -21,15 +22,16 @@ var timer_wave_end = Timer.new()
 var selected_building: int
 
 onready var player_buildings = $"/root/main/player_buildings" as TileMap
-onready var menu_pause = $"/root/main/CanvasLayer/menu_pause" as Popup
+
 onready var astar_nav = $"/root/main/astar_nav" as Node2D
-#onready var util = $"/root/main/util"
+onready var mob_spawn = $"/root/main/mob_spawn" as Node2D
+
 onready var selection = $"/root/main/selection" as Sprite
-#onready var check_game_mode = $"/root/main/CanvasLayer/check_game_mode" as CheckButton 
+
+onready var menu_pause = $"/root/main/CanvasLayer/menu_pause" as Popup
+
 onready var btn_start_wave = $"/root/main/CanvasLayer/btn_start_wave" as TextureButton
 onready var btn_pause = $"/root/main/CanvasLayer/btn_pause" as TextureButton
-onready var mob_spawn = $"/root/main/mob_spawn" as Node2D
-#onready var build_tower = $"/root/main/CanvasLayer/build_tower" as TextureButton
 onready var build_empty = $"/root/main/CanvasLayer/build_empty" as TextureButton
 onready var build_fence = $"/root/main/CanvasLayer/build_fence" as TextureButton
 
@@ -78,17 +80,22 @@ func _handle_selection():
 		if selected_cell:
 			selection.global_position = player_buildings.map_to_world(selected_cell.coordinates)
 		
-		# Selection visibility
-#		selection.visible = not grabbed_chicken == null #
+#		# Selection visibility
+#		 selection.visible = not grabbed_chicken == null
+
+func unpress_buttons():
+	build_empty.pressed = false
+	build_fence.pressed = false
 
 ## SIGNALS
-
 func _on_btn_start_pressed():
 	if game_mode == GameModes.BUILD:
+		unpress_buttons()
 		mob_spawn.start_wave()
 		
 func _on_btn_pause_pressed():
-		menu_pause.switch_pause()
+	unpress_buttons()
+	menu_pause.switch_pause()
 
 func _on_mob_spawn_wave_ended():
 	timer_wave_end.start(1)
@@ -98,27 +105,6 @@ func _on_timer_wave_end_timeout():
 		enter_state(GameModes.BUILD)
 		timer_wave_end.stop()
 
-#func _on_build_tower_pressed():
-#	if not selected_building == Cells.TOWER:
-#		selected_building = Cells.TOWER
-#	else:
-#		selected_building = Cells.EMPTY
-#
-#func _on_build_fence_pressed():
-#	if not selected_building == Cells.FENCE:
-#		selected_building = Cells.FENCE
-#	else:
-#		selected_building = Cells.EMPTY
-#func _on_build_tower_toggled(button_pressed):
-#	if button_pressed:
-#		if build_fence.pressed:
-#			build_fence.pressed = false
-#		selected_building = Cells.TOWER
-#
-#	elif not build_fence.pressed:
-#		selected_building = Cells.EMPTY
-#		print("turning fence off")
-
 func _on_build_empty_toggled(button_pressed):
 	if button_pressed:
 		if build_fence.pressed:
@@ -126,7 +112,7 @@ func _on_build_empty_toggled(button_pressed):
 		selected_building = Cells.EMPTY
 		
 	elif not build_fence.pressed:
-		selected_building = -10
+		selected_building = Cells.INVALID
 	
 func _on_build_fence_toggled(button_pressed):
 	if button_pressed:
@@ -135,10 +121,7 @@ func _on_build_fence_toggled(button_pressed):
 		selected_building = Cells.FENCE
 		
 	elif not build_empty.pressed:
-		selected_building = -10
-#	elif not build_tower.pressed:
-#		selected_building = Cells.EMPTY
-#		print("turning fence off")
+		selected_building = Cells.INVALID
 
 
 ## SETGET
@@ -150,10 +133,6 @@ func _ready():
 	btn_pause.connect("pressed", self, "_on_btn_pause_pressed")
 	mob_spawn.connect("wave_ended", self, "_on_mob_spawn_wave_ended")
 	
-#	build_tower.connect("pressed", self, "_on_build_tower_pressed")
-#	build_fence.connect("pressed", self, "_on_build_fence_pressed")
-	
-#	build_tower.connect("toggled", self, "_on_build_tower_toggled")
 	build_empty.connect("toggled", self, "_on_build_empty_toggled")
 	build_fence.connect("toggled", self, "_on_build_fence_toggled")
 	


### PR DESCRIPTION
Fix wave not ending after all mobs were killed.
Fix wave_clumps sometimes having the wrong mobs (carrying over from
previous wave_clump)
Set build buttons to be unpressed after pausing or starting wave (or grabbing chicken, but that was a previous commit I think).